### PR TITLE
Use gradle 1.10

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.9-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-bin.zip


### PR DESCRIPTION
Gradle 1.10 required with the plugin 0.8.x and gradle 1.10 or 1.11 required with the plugin 0.9.0.
