### PR TITLE
Removed deprecated testReportDir property

### DIFF
--- a/src/main/groovy/org/robolectric/gradle/AndroidTestPlugin.groovy
+++ b/src/main/groovy/org/robolectric/gradle/AndroidTestPlugin.groovy
@@ -162,8 +162,7 @@ class AndroidTestPlugin implements Plugin<Project> {
             testRunTask.testClassesDir = testCompileTask.destinationDir
             testRunTask.group = JavaBasePlugin.VERIFICATION_GROUP
             testRunTask.description = "Run unit tests for Build '$variationName'."
-            // TODO Gradle 1.7: testRunTask.reports.html.destination =
-            testRunTask.testReportDir =
+            testRunTask.reports.html.destination =
                     project.file("$project.buildDir/$TEST_REPORT_DIR/$variant.dirName")
             testRunTask.doFirst {
                 // Prepend the Android runtime onto the classpath.


### PR DESCRIPTION
Since the Android Gradle plugin 0.9.x enforces Gradle >= 1.10 we can remove the deprecated `testReportDir` and use the new `reports.html.destination` property.
