### PR TITLE
Log jUnit classpath for debug purposes

### DIFF
--- a/src/main/groovy/org/robolectric/gradle/AndroidTestPlugin.groovy
+++ b/src/main/groovy/org/robolectric/gradle/AndroidTestPlugin.groovy
@@ -153,6 +153,7 @@ class AndroidTestPlugin implements Plugin<Project> {
                 // Prepend the Android runtime onto the classpath.
                 def androidRuntime = project.files(config.getPlugin().getBootClasspath().join(File.pathSeparator))
                 testRunTask.classpath = testRunClasspath.plus project.files(androidRuntime)
+                log.debug("jUnit classpath: $testRunTask.classpath.asPath")
             }
 
             // Work around http://issues.gradle.org/browse/GRADLE-1682


### PR DESCRIPTION
This would be handy to be able to see the jUnit classPath that gets loaded.
