### PR TITLE
jvmArgs not being passed to GradleWorkerMain (#46)

### DIFF
--- a/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
+++ b/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
@@ -163,6 +163,7 @@ class RobolectricPlugin implements Plugin<Project> {
             testRunTask.systemProperties.put('android.resources', processedResourcesPath)
             testRunTask.systemProperties.put('android.assets', processedAssetsPath)
             testRunTask.setMaxHeapSize(extension.maxHeapSize)
+            testRunTask.setJvmArgs(extension.jvmArgs)
 
             List<String> includePatterns = !extension.includePatterns.empty ? extension.includePatterns : ['**/*Test.class']
             testRunTask.include(includePatterns)


### PR DESCRIPTION
We were having issues with the plugin not passing any JVM arguments to the GradleWorkerMain that was running the tests. This would not allow us to adjust the MaxPermSize in a way that would affect the tests. I passed those along in the same way that maxHeapSize is passed along.
