### PR TITLE
Set the applicationId as packageName...

### DIFF
--- a/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
+++ b/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
@@ -158,8 +158,8 @@ class RobolectricPlugin implements Plugin<Project> {
             // Work around http://issues.gradle.org/browse/GRADLE-1682
             testRunTask.scanForTestClasses = false
 
-			// Set the applicationId as packageName to avoid unknown resources when applicationIdSuffix is used
-			def packageName = project.android.defaultConfig.applicationId
+            // Set the applicationId as packageName to avoid unknown resources when applicationIdSuffix is used
+            def packageName = project.android.defaultConfig.applicationId
             testRunTask.systemProperties.put('android.package', packageName)
 
             // Add the path to the correct manifest, resources, assets as a system property.


### PR DESCRIPTION
...to avoid unknown resources when applicationIdSuffix is used

related to https://github.com/robolectric/robolectric/issues/1150 and https://github.com/robolectric/robolectric-gradle-plugin/issues/48
