### PR TITLE
Added ignoreFailures to DSL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libstdc++6:i386 lib32z1
-  - export COMPONENTS=build-tools-19.0.3,android-19
+  - export COMPONENTS=build-tools-20.0.0,android-20
   - curl -L https://raw.github.com/embarkmobile/android-sdk-installer/version-1/android-sdk-installer | bash /dev/stdin --install=$COMPONENTS
   - source ~/.android-sdk-installer/env
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ apply plugin: 'robolectric'
 Add test-only dependencies using the `androidTestCompile` configuration:
 ```groovy
 androidTestCompile 'junit:junit:4.10'
-androidTestCompile 'org.robolectric:robolectric:2.3+'
+androidTestCompile 'org.robolectric:robolectric:2.3.+'
 androidTestCompile 'com.squareup:fest-android:1.0.+'
 ```
 
@@ -47,7 +47,10 @@ robolectric {
     exclude '**/espresso/**/*.class'
 
     // configure max heap size of the test JVM
-    maxHeapSize = "2048m"
+    maxHeapSize = '2048m'
+
+    // configure whether failing tests should fail the build
+    ignoreFailures true
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'maven'
 apply plugin: 'nexus'
 
 group = 'org.robolectric'
-version = '0.11.0'
+version = '0.12.0'
 
 dependencies {
   repositories {
@@ -22,7 +22,7 @@ dependencies {
 
   compile gradleApi()
   compile 'org.codehaus.groovy:groovy-all:2.2.+'
-  compile 'com.android.tools.build:gradle:0.11.0'
+  compile 'com.android.tools.build:gradle:0.12.0'
 
   testCompile 'junit:junit:4.10'
   testCompile 'org.easytesting:fest-assert-core:2.0M10'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip

--- a/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
+++ b/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
@@ -169,6 +169,7 @@ class RobolectricPlugin implements Plugin<Project> {
             if (!extension.excludePatterns.empty) {
                 testRunTask.exclude(extension.excludePatterns)
             }
+            testRunTask.ignoreFailures = extension.ignoreFailures
 
             testTask.reportOn testRunTask
         }

--- a/src/main/groovy/org/robolectric/gradle/RobolectricTestExtension.groovy
+++ b/src/main/groovy/org/robolectric/gradle/RobolectricTestExtension.groovy
@@ -4,6 +4,7 @@ class RobolectricTestExtension {
     private String maxHeapSize
     private final List<String> includePatterns = new LinkedList<>()
     private final List<String> excludePatterns = new LinkedList<>()
+    private boolean ignoreFailures
 
     String getMaxHeapSize() {
         return maxHeapSize
@@ -27,5 +28,13 @@ class RobolectricTestExtension {
 
     void exclude(String excludePattern) {
         this.excludePatterns.add excludePattern
+    }
+
+    boolean getIgnoreFailures() {
+        return this.ignoreFailures;
+    }
+
+    void ignoreFailures(boolean ignoreFailures) {
+        this.ignoreFailures = ignoreFailures;
     }
 }

--- a/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
+++ b/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
@@ -81,6 +81,15 @@ class RobolectricPluginTest {
     }
 
     @Test
+    public void supportsIngoreFailures() {
+        Project project = evaluatableProject()
+        project.robolectric { ignoreFailures true }
+        project.evaluate()
+
+        assertThat(project.tasks.testDebug.ignoreFailures).isTrue()
+    }
+
+    @Test
     public void createsGenericTestClassesTask() {
         Project project = evaluatableProject()
         project.evaluate()
@@ -136,8 +145,8 @@ class RobolectricPluginTest {
     }
 
     @Test
-    public void parseInstrumentTestCompile_androidGradle_0_11_0() {
-        String androidGradleTool = "com.android.tools.build:gradle:0.11.0"
+    public void parseInstrumentTestCompile_androidGradle_0_12_0() {
+        String androidGradleTool = "com.android.tools.build:gradle:0.12.0"
         String configurationName = "androidTestCompile"
         parseTestCompileDependencyWithAndroidGradle(androidGradleTool, configurationName)
     }
@@ -147,8 +156,8 @@ class RobolectricPluginTest {
         project.apply plugin: 'android'
         project.apply plugin: 'robolectric'
         project.android {
-            compileSdkVersion 19
-            buildToolsVersion "19.0.3"
+            compileSdkVersion 20
+            buildToolsVersion '20.0.0'
         }
         return project
     }
@@ -170,8 +179,8 @@ class RobolectricPluginTest {
         project.apply plugin: 'android'
         project.apply plugin: 'robolectric'
         project.android {
-            compileSdkVersion 19
-            buildToolsVersion "19.0.3"
+            compileSdkVersion 20
+            buildToolsVersion '20.0.0'
         }
 
         project.evaluate()


### PR DESCRIPTION
This mirrors another Gradle `Test` behaviour to the Robolectric Plugin (see http://www.gradle.org/docs/current/dsl/org.gradle.api.tasks.testing.Test.html)

If `ignoreFailures true` is set in the DSL, failed tests will not fail the build.

I also updated the version and Gradle Build tools to `0.12.0`.
