### PR TITLE
Removed some deprecations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'org.gradle.api.plugins:gradle-nexus-plugin:0.2'
+    classpath 'org.gradle.api.plugins:gradle-nexus-plugin:0.3'
   }
 }
 

--- a/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
+++ b/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
@@ -125,7 +125,6 @@ class RobolectricPlugin implements Plugin<Project> {
             def testClassesTaskPerVariation = project.tasks.getByName variationSources.classesTaskName
             testClassesTaskPerVariation.group = null
             testClassesTaskPerVariation.description = null
-            testClassesTaskPerVariation.destinationDir = testDestinationDir.getSingleFile()
 
             def testClassesTaskPerFlavor = project.tasks.create("$projectFlavorName$buildTypeName" + 'TestClasses')
             testClassesTaskPerFlavor.dependsOn testClassesTaskPerVariation
@@ -175,9 +174,9 @@ class RobolectricPlugin implements Plugin<Project> {
     }
 
     class PluginConfiguration {
-        private final Project   project;
-        private final boolean   hasAppPlugin;
-        private final boolean   hasLibPlugin;
+        private final Project project;
+        private final boolean hasAppPlugin;
+        private final boolean hasLibPlugin;
 
         PluginConfiguration(Project project) {
             this.project = project

--- a/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
+++ b/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
@@ -97,8 +97,6 @@ class RobolectricPluginTest {
         def expectedDestination = project.files("$project.buildDir/test-classes").singleFile
         assertThat(project.tasks.compileTestProdDebugJava.destinationDir).isEqualTo(expectedDestination)
         assertThat(project.tasks.compileTestBetaDebugJava.destinationDir).isEqualTo(expectedDestination)
-        assertThat(project.tasks.testProdDebugClasses.destinationDir).isEqualTo(expectedDestination)
-        assertThat(project.tasks.testBetaDebugClasses.destinationDir).isEqualTo(expectedDestination)
         assertThat(project.tasks.processTestProdDebugResources.destinationDir).isEqualTo(expectedDestination)
         assertThat(project.tasks.processTestBetaDebugResources.destinationDir).isEqualTo(expectedDestination)
     }


### PR DESCRIPTION
- Removed The TaskContainer.add() method has been deprecated and is scheduled to be removed in Gradle 2.0. … by updating the gradle-nexus-plugin to 0.3.
- Removed Creating properties on demand (a.k.a. dynamic properties) has been deprecated and is scheduled to be removed in Gradle 2.0. … by removing the creation of this dynamic property.
