### PR TITLE
Removed useless *TestClasses task per variant

### DIFF
--- a/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
+++ b/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
@@ -13,9 +13,9 @@ import org.gradle.api.tasks.testing.TestReport
 class RobolectricPlugin implements Plugin<Project> {
     private static final String[] TEST_DIRS = ['test', 'androidTest']
     private static final String TEST_TASK_NAME = 'test'
-    private static final String TEST_CLASSES_DIR = "test-classes"
-    private static final String TEST_REPORT_DIR = "test-report"
-    private static final String RELEASE_VARIANT = "release"
+    private static final String TEST_CLASSES_DIR = 'test-classes'
+    private static final String TEST_REPORT_DIR = 'test-report'
+    private static final String RELEASE_VARIANT = 'release'
 
     void apply(Project project) {
         def extension = project.extensions.create('robolectric', RobolectricTestExtension)
@@ -125,12 +125,6 @@ class RobolectricPlugin implements Plugin<Project> {
             def testClassesTaskPerVariation = project.tasks.getByName variationSources.classesTaskName
             testClassesTaskPerVariation.group = null
             testClassesTaskPerVariation.description = null
-
-            def testClassesTaskPerFlavor = project.tasks.create("$projectFlavorName$buildTypeName" + 'TestClasses')
-            testClassesTaskPerFlavor.dependsOn testClassesTaskPerVariation
-
-            def testClassesTask = project.tasks.maybeCreate('testClasses')
-            testClassesTask.dependsOn testClassesTaskPerVariation
 
             // don't leave test resources behind
             def processResourcesTask = project.tasks.getByName variationSources.processResourcesTaskName

--- a/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
+++ b/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
@@ -90,14 +90,6 @@ class RobolectricPluginTest {
     }
 
     @Test
-    public void createsGenericTestClassesTask() {
-        Project project = evaluatableProject()
-        project.evaluate()
-
-        assertThat(project.tasks.testClasses).isNotNull()
-    }
-
-    @Test
     public void dumpsAllTestClassFilesAndResourcesIntoTheSameDirectory() {
         Project project = evaluatableProject()
         project.android { productFlavors { prod {}; beta {} } }
@@ -108,38 +100,6 @@ class RobolectricPluginTest {
         assertThat(project.tasks.compileTestBetaDebugJava.destinationDir).isEqualTo(expectedDestination)
         assertThat(project.tasks.processTestProdDebugResources.destinationDir).isEqualTo(expectedDestination)
         assertThat(project.tasks.processTestBetaDebugResources.destinationDir).isEqualTo(expectedDestination)
-    }
-
-    @Test
-    public void uniqueTaskCreatedForEachFlavor() {
-        Project project = evaluatableProject()
-        project.android { productFlavors { prod {}; beta {} } }
-        project.evaluate()
-
-        assertThat(project.tasks.BetaDebugTestClasses).isNotNull()
-        assertThat(project.tasks.ProdDebugTestClasses).isNotNull()
-    }
-
-    @Test
-    public void uniqueTaskCreatedForEachBuildType() {
-        Project project = evaluatableProject()
-        project.android { buildTypes { debug {}; trial {} } }
-        project.evaluate()
-
-        assertThat(project.tasks.DebugTestClasses).isNotNull()
-        assertThat(project.tasks.TrialTestClasses).isNotNull()
-    }
-
-    @Test
-    public void uniqueTaskCreatedForEachFlavorAndBuildType() {
-        Project project = evaluatableProject()
-        project.android { productFlavors { prod {}; beta {} }; buildTypes { debug {}; trial {} } }
-        project.evaluate()
-
-        assertThat(project.tasks.BetaDebugTestClasses).isNotNull()
-        assertThat(project.tasks.BetaTrialTestClasses).isNotNull()
-        assertThat(project.tasks.ProdDebugTestClasses).isNotNull()
-        assertThat(project.tasks.ProdTrialTestClasses).isNotNull()
     }
 
     @Test


### PR DESCRIPTION
Those tasks like `BetaDebugTestClasses` or `ProdTrialTestClasses` were completely useless:
- They have no real actions.
- They just depend on another task.

`./gradlew clean check` finished without a failure and using this with my android app all tests continue to work.
