### PR TITLE
Added option to pass jvmArgs.

### DIFF
--- a/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
+++ b/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
@@ -148,6 +148,7 @@ class RobolectricPlugin implements Plugin<Project> {
             testRunTask.systemProperties.put('android.resources', processedResourcesPath)
             testRunTask.systemProperties.put('android.assets', processedAssetsPath)
             testRunTask.setMaxHeapSize(extension.maxHeapSize)
+            testRunTask.jvmArgs(extension.jvmArgs)
 
             // Set afterTest closure
             if (extension.afterTest != null) {

--- a/src/main/groovy/org/robolectric/gradle/RobolectricTestExtension.groovy
+++ b/src/main/groovy/org/robolectric/gradle/RobolectricTestExtension.groovy
@@ -2,6 +2,7 @@ package org.robolectric.gradle
 
 class RobolectricTestExtension {
     private String maxHeapSize
+    private List<?> jvmArgs = new LinkedList<>()
     private final List<String> includePatterns = new LinkedList<>()
     private final List<String> excludePatterns = new LinkedList<>()
     private boolean ignoreFailures
@@ -21,6 +22,14 @@ class RobolectricTestExtension {
 
     void setMaxHeapSize(String maxHeapSize) {
         this.maxHeapSize = maxHeapSize
+    }
+
+    void jvmArgs(Object... arguments) {
+        jvmArgs.addAll arguments
+    }
+
+    List<?> getJvmArgs() {
+        return jvmArgs
     }
 
     List<String> getIncludePatterns() {

--- a/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
+++ b/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
@@ -95,6 +95,16 @@ class RobolectricPluginTest {
     }
 
     @Test
+    public void supportsAddingJvmArgs_viaTheAndroidTestExtension() {
+        Project project = evaluatableProject()
+        project.robolectric { jvmArgs "-XX:TestArgument0", "-XX:TestArgument1" }
+        project.evaluate()
+
+        assertThat(project.tasks.testDebug.getJvmArgs()).contains("-XX:TestArgument0")
+        assertThat(project.tasks.testDebug.getJvmArgs()).contains("-XX:TestArgument1")
+    }
+
+    @Test
     public void supportsMultipleIncludeAndExcludePatterns() {
         Project project = evaluatableProject()
         project.robolectric {


### PR DESCRIPTION
Patch for issue #46. This allows for passing jvmArgs through the test extension, in the spirit of http://www.gradle.org/docs/current/javadoc/org/gradle/process/JavaForkOptions.html#jvmArgs(java.lang.Object...)

```
robolectric {
   // Increase MaxPermSize
   jvmArgs '-XX:MaxPermSize=512m'
}
```

This is my first Groovy contribution, so I apologize if anything is weird :)
