### PR TITLE
Add coveralls.io code coverage via jacoco.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ android:
 
 script:
   - ./gradlew check --stacktrace
+
+after_success:
+- ./gradlew jacocoTestReport coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Robolectric Gradle Plugin
 
-[![Build Status](https://secure.travis-ci.org/robolectric/robolectric-gradle-plugin.png?branch=master)](http://travis-ci.org/robolectric/robolectric-gradle-plugin)
+[![Build Status](https://secure.travis-ci.org/robolectric/robolectric-gradle-plugin.png?branch=master)](http://travis-ci.org/robolectric/robolectric-gradle-plugin) [![Coverage Status](https://coveralls.io/repos/kageiit/robolectric-gradle-plugin/badge.png?branch=add_coveralls_io_code_coverage)](https://coveralls.io/r/kageiit/robolectric-gradle-plugin?branch=add_coveralls_io_code_coverage)
 
 A Gradle plugin which enables Robolectric tests.
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,15 @@ buildscript {
 
     dependencies {
         classpath 'org.gradle.api.plugins:gradle-nexus-plugin:0.3'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1'
     }
 }
 
 apply plugin: 'groovy'
 apply plugin: 'maven'
 apply plugin: 'nexus'
+apply plugin: 'jacoco'
+apply plugin: 'com.github.kt3k.coveralls'
 
 group = 'org.robolectric'
 version = '0.14.0-SNAPSHOT'
@@ -34,6 +37,12 @@ dependencies {
 install {
     repositories.mavenInstaller {
         pom.artifactId = 'robolectric-gradle-plugin'
+    }
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true
     }
 }
 


### PR DESCRIPTION
Enables code coverage reporting upon pull requests etc. using [Coveralls.io](https://coveralls.io/).

![Coverage Badge](https://cloud.githubusercontent.com/assets/291148/4913509/2eca1396-64b3-11e4-8348-ff3a87c9f917.png)
![Coveralls Config](https://cloud.githubusercontent.com/assets/291148/4913511/318f4588-64b3-11e4-8bed-bae01163cd31.png)

Will change the badge url if this is approved :+1: 