### PR TITLE
Added a runtime check for the Android Gradle plugin version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 local.properties
 
 *~
+userHome

--- a/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
+++ b/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
@@ -10,6 +10,7 @@ import com.android.build.gradle.AppPlugin
 import com.android.build.gradle.LibraryPlugin
 
 class RobolectricPlugin implements Plugin<Project> {
+    private static final String[] SUPPORTED_ANDROID_VERSIONS = ['0.14.'];
     private static final String TEST_TASK_NAME = 'test'
     private static final String TEST_CLASSES_DIR = 'test-classes'
     private static final String TEST_REPORT_DIR = 'test-report'
@@ -19,6 +20,13 @@ class RobolectricPlugin implements Plugin<Project> {
         def extension = project.extensions.create('robolectric', RobolectricTestExtension)
         def log = project.logger
         def config = new PluginConfiguration(project)
+
+        def androidGradlePlugin = project.buildscript.configurations.classpath.dependencies.find {
+            it.group != null && it.group.equals('com.android.tools.build') && it.name.equals('gradle')
+        }
+        if (androidGradlePlugin != null && !checkAndroidVersion(androidGradlePlugin.version)) {
+            throw new IllegalStateException("The Android Gradle plugin ${androidGradlePlugin.version} is not supported.")
+        }
 
         // Create the configuration for test-only dependencies.
         def testConfiguration = project.configurations.create(TEST_TASK_NAME + 'Compile')
@@ -176,6 +184,16 @@ class RobolectricPlugin implements Plugin<Project> {
 
             testTask.reportOn testRunTask
         }
+    }
+
+    static boolean checkAndroidVersion(String version) {
+        for (String supportedVersion : SUPPORTED_ANDROID_VERSIONS) {
+            if (version.startsWith(supportedVersion)) {
+                return true
+            }
+        }
+
+        return false
     }
 
     class PluginConfiguration {


### PR DESCRIPTION
From now on the plugin will fail if an unsupported Android Gradle plugin is detected. For the upcoming `0.14.0` release of the robolectric-gradle-plugin we support all `0.14.x` releases.

Refs #14 and #79 
