### PR TITLE
Fix classpath unit tests

### DIFF
--- a/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
+++ b/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
@@ -272,7 +272,7 @@ class RobolectricPluginTest {
         project.evaluate()
 
         assertThat(project.tasks.compileTestDebugJava.classpath.files.find {
-            it.absolutePath.contains('junit/junit/4.8')
+            it.absolutePath.contains("junit${File.separator}junit${File.separator}4.8")
         }).isNotNull()
     }
 
@@ -288,7 +288,7 @@ class RobolectricPluginTest {
         project.evaluate()
 
         assertThat(project.tasks.compileTestDebugJava.classpath.files.find {
-            it.absolutePath.contains('com.squareup.assertj/assertj-android/1.0.0/classes.jar')
+            it.absolutePath.contains("com.squareup.assertj${File.separator}assertj-android${File.separator}1.0.0${File.separator}classes.jar")
         }).isNotNull()
     }
 


### PR DESCRIPTION
This fixes unit test errors caused by different path separators on Windows operating systems.

I was getting two unit test failures trying to build this project on Windows:

```
:test

org.robolectric.gradle.RobolectricPluginTest > ensureJarDependenciesOnClasspath FAILED
    java.lang.AssertionError at RobolectricPluginTest.groovy:274

org.robolectric.gradle.RobolectricPluginTest > ensureAarDependenciesOnClasspath FAILED
    java.lang.AssertionError at RobolectricPluginTest.groovy:290
```

Project now builds fine on Windows 8.1 and Ubuntu 14.10
