### PR TITLE
Allow for more than one jar on project bootclasspath

### DIFF
--- a/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
+++ b/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
@@ -148,9 +148,9 @@ class RobolectricPlugin implements Plugin<Project> {
             testRunTask.reports.html.destination =
                     project.file("$project.buildDir/$TEST_REPORT_DIR/$variant.dirName")
             testRunTask.doFirst {
-                // Prepend the Android runtime onto the classpath.
-                def androidRuntime = project.files(config.plugin.getBootClasspath().join(File.pathSeparator))
-                testRunTask.classpath = testRunClasspath.plus project.files(androidRuntime)
+                // Append the Android runtime onto the classpath.
+                def androidRuntime = project.files(config.plugin.getBootClasspath())
+                testRunTask.classpath = testRunClasspath.plus androidRuntime
                 log.debug("jUnit classpath: $testRunTask.classpath.asPath")
             }
 


### PR DESCRIPTION
It's possible for there to be more than one jar in the configuration's
bootclasspath (ie, when building projects for specific ROMs). Also,
fix comment to indicate where the bootclasspath actually gets added
(git blame shows that it switched from being prepended to being
appended intentionally).