### PR TITLE
issue-117 "Could not normalize path for file" error occurs on Windows when $testRunTask.classpath.asPath is called

### DIFF
--- a/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
+++ b/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
@@ -128,7 +128,6 @@ class RobolectricPlugin implements Plugin<Project> {
                 // Prepend the Android runtime onto the classpath.
                 def androidRuntime = project.files(config.getPlugin().getBootClasspath().join(File.pathSeparator))
                 testRunTask.classpath = testRunClasspath.plus project.files(androidRuntime)
-                log.debug("jUnit classpath: $testRunTask.classpath.asPath")
             }
 
             // Work around http://issues.gradle.org/browse/GRADLE-1682


### PR DESCRIPTION
[Problem]
'gradle testDebug' failed on Window and Mac

[RootCause]
$testRunTask.classpath.asPath throw exception

[Solution]
remove log.debug("jUnit classpath: $testRunTask.classpath.asPath")

[Test]
Run 'gradle testDebug'

[ISSUE Link]
https://github.com/robolectric/robolectric-gradle-plugin/issues/117
