### PR TITLE
Fixes #137. Uses variants.instead of variant names

### DIFF
--- a/src/main/groovy/org/robolectric/gradle/Configuration.groovy
+++ b/src/main/groovy/org/robolectric/gradle/Configuration.groovy
@@ -44,23 +44,16 @@ class Configuration {
     }
 
     /**
-     * Return the all variant names.
-     *
-     * @return  Collection of variant names.
+     * Return the all variants
      */
-    Collection<String> getVariantNames() {
-        def rval = new ArrayList<String>()
-        for (String type : getBuildTypeNames()) {
-            def flavors = getFlavorNames()
-            if (flavors.isEmpty()) {
-                rval.add("${type}")
-            } else {
-                for (String flavor : flavors) {
-                    rval.add("${flavor}${type.capitalize()}")
-                }
-            }
+    def getVariants() {
+        final def variants
+        if (hasAppPlugin) {
+            variants = project.android.applicationVariants
+        } else {
+            variants = project.android.libraryVariants
         }
-        return rval
+        return variants
     }
 
     /**

--- a/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
+++ b/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
@@ -24,8 +24,7 @@ class RobolectricPlugin implements Plugin<Project> {
             }
 
             // Configure the test tasks
-            for (String name : configuration.getVariantNames()) {
-                def variant = configuration.getVariant(name)
+            configuration.variants.all { variant ->
                 def task = project.tasks.findByName("test${variant.name.capitalize()}")
 
                 // Set RobolectricTestRunner properties


### PR DESCRIPTION
Using `.all` will execute the closure for all the future items too. [See the doc](https://gradle.org/docs/current/javadoc/org/gradle/api/DomainObjectCollection.html#all(org.gradle.api.Action))

This should fix #137 