### PR TITLE
Added support for Android Gradle plugin 1.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ jdk:
 
 android:
   components:
-    - build-tools-21.1.2
-    - android-21
+    - build-tools-22.0.1
+    - android-22
 
 script:
   - ./gradlew check --stacktrace

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin piggy-backs on the unit testing support added in version 1.1.0 of th
 
 ## Compatibility
 
-Currently compatible with version 1.1.0 of the Android Gradle plugin.
+Currently compatible with version 1.2.x of the Android Gradle plugin.
 
 ## Basic Usage
 
@@ -37,6 +37,15 @@ Place your tests in `src/test/java`. You can also add per-build type and per-fla
 
 ```groovy
 robolectric {
+    // configure whether unsupported versions should result in a failure
+    ignoreVersionCheck true
+}
+```
+
+Despite from the Robolectric-specific configurations you can also configure the underlying `Test` tasks via
+
+```groovy
+android.testOptions.unitTests.all {
     // Configure includes / excludes
     include '**/*Test.class'
     exclude '**/espresso/**/*.class'
@@ -46,10 +55,10 @@ robolectric {
 
     // Configure the test JVM arguments - Does not apply to Java 8
     jvmArgs '-XX:MaxPermSize=512m', '-XX:-UseSplitVerifier'
-    
+
     // Specify max number of processes (default is 1)
     maxParallelForks = 4
-    
+
     // Specify max number of test classes to execute in a test process
     // before restarting the process (default is unlimited)
     forkEvery = 150
@@ -63,6 +72,8 @@ robolectric {
     }
 }
 ```
+
+See the [DSL reference][1] for more information.
 
 ## License
 
@@ -81,3 +92,4 @@ robolectric {
     See the License for the specific language governing permissions and
     limitations under the License.
 
+ [1]: http://gradle.org/docs/current/dsl/org.gradle.api.tasks.testing.Test.html

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
     compile gradleApi()
     compile localGroovy()
-    compile "com.android.tools.build:gradle:1.1.0"
+    compile "com.android.tools.build:gradle:1.2.0"
 
     testCompile "junit:junit:4.10"
     testCompile "org.assertj:assertj-core:1.7.0"

--- a/src/main/groovy/org/robolectric/gradle/Configuration.groovy
+++ b/src/main/groovy/org/robolectric/gradle/Configuration.groovy
@@ -1,9 +1,9 @@
 package org.robolectric.gradle
 
-import org.gradle.api.Project
 import com.android.build.gradle.AppPlugin
 import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.api.BaseVariant
+import org.gradle.api.Project
 
 /**
  * Class used to obtain information about the project configuration.
@@ -12,21 +12,15 @@ class Configuration {
     private final Project project
     private final boolean hasAppPlugin
     private final boolean hasLibPlugin
-    private static final String[] SUPPORTED_ANDROID_VERSIONS = ['1.1.']
+    private static final String[] SUPPORTED_ANDROID_VERSIONS = ['1.2.']
 
-    /**
-     * Class constructor.
-     *
-     * @param   project
-     *          Gradle project.
-     */
     Configuration(Project project) {
         this.project = project
         this.hasAppPlugin = project.plugins.find { p -> p instanceof AppPlugin }
         this.hasLibPlugin = project.plugins.find { p -> p instanceof LibraryPlugin }
 
         if (!hasAppPlugin && !hasLibPlugin) {
-            throw new IllegalStateException("The 'com.android.application' or 'com.android.library' plugin is required.")
+            throw new IllegalStateException("robolectric-gradle-plugin: The 'com.android.application' or 'com.android.library' plugin is required.")
         }
     }
 
@@ -39,25 +33,17 @@ class Configuration {
         }
 
         if (androidGradlePlugin != null && !checkVersion(androidGradlePlugin.version)) {
-            throw new IllegalStateException("The Android Gradle plugin ${androidGradlePlugin.version} is not supported.")
+            throw new IllegalStateException("robolectric-gradle-plugin: The Android Gradle plugin ${androidGradlePlugin.version} is not supported.")
         }
     }
 
     /**
      * Return all variants.
      *
-     * @return  Collection of variants.
+     * @return Collection of variants.
      */
     Collection<BaseVariant> getVariants() {
         return hasAppPlugin ? project.android.applicationVariants : project.android.libraryVariants
-    }
-
-    private Collection<String> getFlavorNames() {
-        return project.android.productFlavors.collect { flavor -> flavor.name as String }
-    }
-
-    private Collection<String> getBuildTypeNames() {
-        return project.android.buildTypes.collect { type -> type.name as String }
     }
 
     private static boolean checkVersion(String version) {

--- a/src/main/groovy/org/robolectric/gradle/RobolectricExtension.groovy
+++ b/src/main/groovy/org/robolectric/gradle/RobolectricExtension.groovy
@@ -1,59 +1,7 @@
 package org.robolectric.gradle
 
 class RobolectricExtension {
-    private long forkEvery
-    private int maxParallelForks = 1
-    private final List<String> jvmArgs = new LinkedList<>()
-    private final List<String> includePatterns = new LinkedList<>()
-    private final List<String> excludePatterns = new LinkedList<>()
-    String maxHeapSize
-    boolean ignoreFailures
-    Closure afterTest
+
     boolean ignoreVersionCheck
 
-    int getMaxParallelForks() {
-        return maxParallelForks
-    }
-
-    void setMaxParallelForks(int maxParallelForks) {
-        if (maxParallelForks < 1) {
-            throw new IllegalArgumentException("Cannot set maxParallelForks to a value less than 1.")
-        }
-        this.maxParallelForks = maxParallelForks;
-    }
-
-    long getForkEvery() {
-        return forkEvery
-    }
-
-    void setForkEvery(Long forkEvery) {
-        if (forkEvery != null && forkEvery < 0) {
-            throw new IllegalArgumentException("Cannot set forkEvery to a value less than 0.")
-        }
-        this.forkEvery = forkEvery == null ? 0 : forkEvery;
-    }
-
-    List<String> getJvmArgs() {
-        return jvmArgs
-    }
-
-    void jvmArgs(String... jvmArgs) {
-        this.jvmArgs.addAll jvmArgs
-    }
-
-    List<String> getIncludePatterns() {
-        return this.includePatterns
-    }
-
-    void include(String... includePattern) {
-        this.includePatterns.addAll includePattern
-    }
-
-    List<String> getExcludePatterns() {
-        return this.excludePatterns
-    }
-
-    void exclude(String... excludePattern) {
-        this.excludePatterns.addAll excludePattern
-    }
 }

--- a/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
+++ b/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
@@ -2,7 +2,6 @@ package org.robolectric.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import com.android.build.gradle.api.BaseVariant
 
 /**
  * Robolectric gradle plugin.
@@ -17,7 +16,6 @@ class RobolectricPlugin implements Plugin<Project> {
         // Configure the project
         def configuration = new Configuration(project)
         project.afterEvaluate {
-
             // Verify the plugin version
             if (!extension.ignoreVersionCheck) {
                 configuration.validate()
@@ -25,47 +23,25 @@ class RobolectricPlugin implements Plugin<Project> {
 
             // Configure the test tasks
             configuration.variants.all { variant ->
-                def task = project.tasks.findByName("test${variant.name.capitalize()}")
+                def taskName = "test${variant.name.capitalize()}"
+                def assets = variant.mergeAssets.outputDir
+                def manifest = variant.outputs.first().processManifest.manifestOutputFile
+                def resources = variant.mergeResources.outputDir
+                def packageName = project.android.defaultConfig.applicationId
 
                 // Set RobolectricTestRunner properties
-                task.systemProperty("android.assets", getAssets(variant))
-                task.systemProperty("android.manifest", getManifestFile(variant))
-                task.systemProperty("android.resources", getResources(variant))
-                task.systemProperty("android.package", getPackageName(project))
+                def task = project.tasks.findByName(taskName)
+                task.systemProperty "android.assets", assets
+                task.systemProperty "android.manifest", manifest
+                task.systemProperty "android.resources", resources
+                task.systemProperty "android.package", packageName
 
-                // Set extension properties
-                task.setJvmArgs(extension.jvmArgs)
-                task.setForkEvery(extension.forkEvery)
-                task.setMaxHeapSize(extension.maxHeapSize)
-                task.setMaxParallelForks(extension.maxParallelForks)
-
-                // Set afterTest closure
-                if (extension.afterTest != null) {
-                    task.afterTest(extension.afterTest)
-                }
-
-                project.logger.info("Configuring task: ${task.name}")
-                project.logger.info("Robolectric assets: ${getAssets(variant)}")
-                project.logger.info("Robolectric manifest: ${getManifestFile(variant)}")
-                project.logger.info("Robolectric resources: ${getResources(variant)}")
-                project.logger.info("Robolectric package name: ${getPackageName(project)}")
+                project.logger.info("Configuring task: ${taskName}")
+                project.logger.info("Robolectric assets: ${assets}")
+                project.logger.info("Robolectric manifest: ${manifest}")
+                project.logger.info("Robolectric resources: ${resources}")
+                project.logger.info("Robolectric package: ${packageName}")
             }
         }
-    }
-
-    private static String getPackageName(Project project) {
-        return project.android.defaultConfig.applicationId
-    }
-
-    private static File getAssets(BaseVariant variant) {
-        return variant.mergeAssets.outputDir
-    }
-
-    private static File getResources(BaseVariant variant) {
-        return variant.mergeResources.outputDir
-    }
-
-    private static File getManifestFile(BaseVariant variant) {
-        return variant.outputs.first().processManifest.manifestOutputFile
     }
 }

--- a/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
+++ b/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
@@ -1,20 +1,15 @@
 package org.robolectric.gradle
 
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.ExpectedException
-import org.gradle.api.Task
 import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
-import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.api.Task
 import org.gradle.api.internal.plugins.PluginApplicationException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
 
 import static org.assertj.core.api.Assertions.assertThat
 
 class RobolectricPluginTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none()
-
     @Test
     public void plugin_detectsLibraryPlugin() {
         final Project project = ProjectBuilder.builder().build()
@@ -66,7 +61,7 @@ class RobolectricPluginTest {
 
     @Test
     public void plugin_acceptsSupportedAndroidPlugin() {
-        final Project project = createProject("com.android.tools.build:gradle:1.1.0")
+        final Project project = createProject("com.android.tools.build:gradle:1.2.0")
         project.evaluate()
     }
 
@@ -162,155 +157,6 @@ class RobolectricPluginTest {
 
     }
 
-    @Test
-    public void configuration_supportsSettingAnExcludePattern() {
-        final Project project = createProject()
-        project.robolectric {
-            exclude "**/lame_tests/**"
-        }
-        project.evaluate()
-
-        project.tasks.withType(Test).each { task ->
-            assertThat(task.getExcludes()).contains("**/lame_tests/**")
-        }
-    }
-
-    @Test
-    public void configuration_supportsAddingJvmArgs() {
-        final Project project = createProject()
-        project.robolectric {
-            jvmArgs "-XX:TestArgument0", "-XX:TestArgument1"
-        }
-        project.evaluate()
-
-        project.tasks.withType(Test).each { task ->
-            assertThat(task.getJvmArgs()).contains("-XX:TestArgument0")
-            assertThat(task.getJvmArgs()).contains("-XX:TestArgument1")
-        }
-    }
-
-    @Test
-    public void configuration_supportsAddingMaxHeapSize() {
-        final Project project = createProject()
-        project.robolectric {
-            maxHeapSize = "1024m"
-        }
-        project.evaluate()
-
-        project.tasks.withType(Test).each { task ->
-            assertThat(task.getMaxHeapSize()).isEqualTo("1024m")
-        }
-    }
-
-    @Test
-    public void configuration_supportsAddingMaxParallelForks() {
-        final Project project = createProject()
-        project.robolectric {
-            maxParallelForks = 4
-        }
-        project.evaluate()
-
-        project.tasks.withType(Test).each { task ->
-            assertThat(task.getMaxParallelForks()).isEqualTo(4)
-        }
-    }
-
-    @Test
-    public void configuration_setMaxParallelForksDefaultsToOne() {
-        final Project project = createProject()
-        project.evaluate()
-
-        project.tasks.withType(Test).each { task ->
-            assertThat(task.getMaxParallelForks()).isEqualTo(1)
-        }
-    }
-
-    @Test
-    public void configuration_shouldThrowException_whenMaxParallelForksLessThanOne() {
-        final Project project = createProject()
-
-        thrown.expect(IllegalArgumentException.class)
-        thrown.expectMessage("Cannot set maxParallelForks to a value less than 1.")
-        project.robolectric {
-            maxParallelForks = 0
-        }
-    }
-
-    @Test
-    public void configuration_supportsAddingForkEvery() {
-        final Project project = createProject()
-        project.robolectric { forkEvery = 150 }
-        project.evaluate()
-
-        project.tasks.withType(Test).each { task ->
-            assertThat(task.getForkEvery()).isEqualTo(150)
-        }
-    }
-
-    @Test
-    public void configuration_setForkEveryDefaultsToZero() {
-        final Project project = createProject()
-        project.evaluate()
-
-        project.tasks.withType(Test).each { task ->
-            assertThat(task.getForkEvery()).isEqualTo(0)
-        }
-    }
-
-    @Test
-    public void configuration_setForkEveryToZeroWhenConfiguredNull() {
-        final Project project = createProject()
-        project.robolectric {
-            forkEvery = null
-        }
-        project.evaluate()
-
-        project.tasks.withType(Test).each { task ->
-            assertThat(task.getForkEvery()).isEqualTo(0)
-        }
-    }
-
-    @Test
-    public void configuration_shouldThrowException_whenForkEveryNegative() {
-        final Project project = createProject()
-
-        thrown.expect(IllegalArgumentException.class)
-        thrown.expectMessage("Cannot set forkEvery to a value less than 0.")
-        project.robolectric {
-            forkEvery = -1
-        }
-    }
-
-    @Test
-    public void configuration_supportsMultipleIncludeAndExcludePatterns() {
-        final Project project = createProject()
-        project.robolectric {
-            exclude "**/lame_tests/**"
-            exclude "**/lame_tests2/**", "**/lame_tests3/**"
-            include "**/robo_tests/**"
-            include "**/robo_tests2/**", "**/robo_tests3/**"
-        }
-        project.evaluate()
-
-        project.tasks.withType(Test).each { task ->
-            assertThat(task.excludes).contains("**/lame_tests/**", "**/lame_tests2/**", "**/lame_tests3/**")
-            assertThat(task.includes).contains("**/robo_tests/**", "**/robo_tests2/**", "**/robo_tests3/**")
-        }
-    }
-
-    @Test
-    public void configuration_supportsIgnoreFailures() {
-        final Project project = createProject()
-        project.robolectric {
-            ignoreFailures true
-        }
-        project.evaluate()
-
-        project.tasks.withType(Test).each { task ->
-            assertThat(task.ignoreFailures()).isTrue()
-        }
-    }
-
     private static Project createProject() {
         return createProject("com.android.application", null)
     }
@@ -334,8 +180,8 @@ class RobolectricPluginTest {
         project.apply plugin: plugin
         project.apply plugin: "org.robolectric"
         project.android {
-            compileSdkVersion 21
-            buildToolsVersion "21.1.2"
+            compileSdkVersion 22
+            buildToolsVersion "22.0.1"
 
             defaultConfig {
                 applicationId "com.example"


### PR DESCRIPTION
This update added support for customization of the `Test` task via `android.testOptions.unitTests.all` (see http://b.android.com/140241 and http://r.android.com/136596). As a result we can minimize our `RobolectricExtension` to only contain Robolectric-specific configurations. Unfortunately, this is a backwards-incompatible change.

We can also discuss if the remaining `ignoreVersionCheck` is still useful as the API / DSL is stable since the 1.0.0 release.