### PR TITLE
Support Android Gradle plugin 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin piggy-backs on the unit testing support added in version 1.1.0 of th
 
 ## Compatibility
 
-Currently compatible with version 1.1.0 of the Android Gradle plugin.
+Currently compatible with version 1.1.x and 1.2.x of the Android Gradle plugin.
 
 ## Basic Usage
 

--- a/src/main/groovy/org/robolectric/gradle/Configuration.groovy
+++ b/src/main/groovy/org/robolectric/gradle/Configuration.groovy
@@ -12,7 +12,7 @@ class Configuration {
     private final Project project
     private final boolean hasAppPlugin
     private final boolean hasLibPlugin
-    private static final String[] SUPPORTED_ANDROID_VERSIONS = ['1.1.']
+    private static final String[] SUPPORTED_ANDROID_VERSIONS = ['1.1.', '1.2.']
 
     /**
      * Class constructor.

--- a/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
+++ b/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
@@ -70,6 +70,12 @@ class RobolectricPluginTest {
         project.evaluate()
     }
 
+    @Test(expected = ProjectConfigurationException.class)
+    public void plugin_failsWithFutureAndroidPlugin() {
+        final Project project = createProject("com.android.tools.build:gradle:1.3.0")
+        project.evaluate()
+    }
+
     @Test
     public void plugin_configuresTestTasks() {
         final Project project = createProject()


### PR DESCRIPTION
If #150 is not accepted we should at least support Android Gradle plugin 1.2.x by adding it to the list of supported versions.