### PR TITLE
Changed version whitelisting to blacklisting

### DIFF
--- a/src/main/groovy/org/robolectric/gradle/Configuration.groovy
+++ b/src/main/groovy/org/robolectric/gradle/Configuration.groovy
@@ -9,10 +9,10 @@ import org.gradle.api.Project
  * Class used to obtain information about the project configuration.
  */
 class Configuration {
+    private static final String[] UNSUPPORTED_ANDROID_VERSIONS = ['0.', '1.0.', '1.1.']
     private final Project project
     private final boolean hasAppPlugin
     private final boolean hasLibPlugin
-    private static final String[] SUPPORTED_ANDROID_VERSIONS = ['1.2.']
 
     Configuration(Project project) {
         this.project = project
@@ -32,7 +32,7 @@ class Configuration {
             it.group != null && it.group.equals('com.android.tools.build') && it.name.equals('gradle')
         }
 
-        if (androidGradlePlugin != null && !checkVersion(androidGradlePlugin.version)) {
+        if (androidGradlePlugin != null && isUnsupported(androidGradlePlugin.version)) {
             throw new IllegalStateException("robolectric-gradle-plugin: The Android Gradle plugin ${androidGradlePlugin.version} is not supported.")
         }
     }
@@ -46,9 +46,9 @@ class Configuration {
         return hasAppPlugin ? project.android.applicationVariants : project.android.libraryVariants
     }
 
-    private static boolean checkVersion(String version) {
-        for (String supportedVersion : SUPPORTED_ANDROID_VERSIONS) {
-            if (version.startsWith(supportedVersion)) {
+    private static boolean isUnsupported(String version) {
+        for (def unsupportedVersion : UNSUPPORTED_ANDROID_VERSIONS) {
+            if (version.startsWith(unsupportedVersion)) {
                 return true
             }
         }

--- a/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
+++ b/src/test/groovy/org/robolectric/gradle/RobolectricPluginTest.groovy
@@ -45,14 +45,26 @@ class RobolectricPluginTest {
     }
 
     @Test(expected = ProjectConfigurationException.class)
-    public void plugin_failsWithOutdatedAndroidPlugin() {
+    public void plugin_failsWithOutdatedAndroidPlugin_0120() {
         final Project project = createProject("com.android.tools.build:gradle:0.12.0")
+        project.evaluate()
+    }
+
+    @Test(expected = ProjectConfigurationException.class)
+    public void plugin_failsWithOutdatedAndroidPlugin_100() {
+        final Project project = createProject("com.android.tools.build:gradle:1.0.0")
+        project.evaluate()
+    }
+
+    @Test(expected = ProjectConfigurationException.class)
+    public void plugin_failsWithOutdatedAndroidPlugin_110() {
+        final Project project = createProject("com.android.tools.build:gradle:1.1.0")
         project.evaluate()
     }
 
     @Test
     public void plugin_acceptsOutdatedAndroidPluginByExtension() {
-        final Project project = createProject("com.android.tools.build:gradle:0.12.0")
+        final Project project = createProject("com.android.tools.build:gradle:1.1.0")
         project.robolectric {
             ignoreVersionCheck true
         }
@@ -190,19 +202,19 @@ class RobolectricPluginTest {
         return project
     }
 
-    private static String getPackage(Task testDebug) {
-        return testDebug.getSystemProperties().get("android.package")
+    private static String getPackage(Task task) {
+        return task.systemProperties.get("android.package")
     }
 
     private static String getAssetPath(Task task) {
-        return task.getSystemProperties().get("android.assets").getPath()
+        return task.systemProperties.get("android.assets").getPath()
     }
 
     private static String getManifestPath(Task task) {
-        return task.getSystemProperties().get("android.manifest").getPath()
+        return task.systemProperties.get("android.manifest").getPath()
     }
 
     private static String getResourcePath(Task task) {
-        return task.getSystemProperties().get("android.resources").getPath()
+        return task.systemProperties.get("android.resources").getPath()
     }
 }


### PR DESCRIPTION
I changed the way we detect incompatible versions from a whitelisting to a blacklisting since it is unlikely that a new version of the Android Gradle plugin breaks out current (very lightweight) implementation.