### PR TITLE
Replaced Collection<BaseVariant> with DomainObjectCollection<…>

### DIFF
--- a/src/main/groovy/org/robolectric/gradle/Configuration.groovy
+++ b/src/main/groovy/org/robolectric/gradle/Configuration.groovy
@@ -3,6 +3,7 @@ package org.robolectric.gradle
 import com.android.build.gradle.AppPlugin
 import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.api.BaseVariant
+import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Project
 
 /**
@@ -28,7 +29,7 @@ class Configuration {
      *
      * @return Collection of variants.
      */
-    Collection<BaseVariant> getVariants() {
+    DomainObjectCollection<BaseVariant> getVariants() {
         return hasAppPlugin ? project.android.applicationVariants : project.android.libraryVariants
     }
 }


### PR DESCRIPTION
The IDE now recognizes that the variants.all(…) method is available.