### PR TITLE
Removed project.afterEvaluate(…)

### DIFF
--- a/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
+++ b/src/main/groovy/org/robolectric/gradle/RobolectricPlugin.groovy
@@ -1,6 +1,5 @@
 package org.robolectric.gradle
 
-import com.android.build.gradle.api.BaseVariant
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
@@ -14,28 +13,27 @@ class RobolectricPlugin implements Plugin<Project> {
     void apply(Project project) {
         // Configure the project
         def configuration = new Configuration(project)
-        project.afterEvaluate {
-            // Configure the test tasks
-            configuration.variants.all { BaseVariant variant ->
-                def taskName = "test${variant.name.capitalize()}"
-                def assets = variant.mergeAssets.outputDir
-                def manifest = variant.outputs.first().processManifest.manifestOutputFile
-                def resources = variant.mergeResources.outputDir
-                def packageName = project.android.defaultConfig.applicationId
 
-                // Set RobolectricTestRunner properties
-                def task = project.tasks.findByName(taskName) as Test
-                task.systemProperty "android.assets", assets
-                task.systemProperty "android.manifest", manifest
-                task.systemProperty "android.resources", resources
-                task.systemProperty "android.package", packageName
+        // Configure the test tasks
+        configuration.variants.all { variant ->
+            def taskName = "test${variant.name.capitalize()}"
+            def assets = variant.mergeAssets.outputDir
+            def manifest = variant.outputs.first().processManifest.manifestOutputFile
+            def resources = variant.mergeResources.outputDir
+            def packageName = project.android.defaultConfig.applicationId
 
-                project.logger.info("Configuring task: ${taskName}")
-                project.logger.info("Robolectric assets: ${assets}")
-                project.logger.info("Robolectric manifest: ${manifest}")
-                project.logger.info("Robolectric resources: ${resources}")
-                project.logger.info("Robolectric package: ${packageName}")
-            }
+            // Set RobolectricTestRunner properties
+            def task = project.tasks.findByName(taskName) as Test
+            task.systemProperty "android.assets", assets
+            task.systemProperty "android.manifest", manifest
+            task.systemProperty "android.resources", resources
+            task.systemProperty "android.package", packageName
+
+            project.logger.info("Configuring task: ${taskName}")
+            project.logger.info("Robolectric assets: ${assets}")
+            project.logger.info("Robolectric manifest: ${manifest}")
+            project.logger.info("Robolectric resources: ${resources}")
+            project.logger.info("Robolectric package: ${packageName}")
         }
     }
 }


### PR DESCRIPTION
There is no need that we configure the Tests after the project was evaluated since we rely on the `DomainObjectCollection.all(…)` that automagically "executes the closure against any objects subsequently added to this collection." (per Groovy doc)
